### PR TITLE
fix: improve certificate URL validation

### DIFF
--- a/amazon.go
+++ b/amazon.go
@@ -107,10 +107,6 @@ func readCert(certURL string) ([]byte, error) {
 }
 
 func verifyCertURL(path string) bool {
-	if !strings.HasSuffix(path, "/echo.api/echo-api-cert.pem") {
-		return false
-	}
-
 	if !strings.HasPrefix(path, "https://s3.amazonaws.com/echo.api/") && !strings.HasPrefix(path, "https://s3.amazonaws.com:443/echo.api/") {
 		return false
 	}

--- a/amazon.go
+++ b/amazon.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -107,9 +108,18 @@ func readCert(certURL string) ([]byte, error) {
 }
 
 func verifyCertURL(path string) bool {
-	if !strings.HasPrefix(path, "https://s3.amazonaws.com/echo.api/") && !strings.HasPrefix(path, "https://s3.amazonaws.com:443/echo.api/") {
+	link, _ := url.Parse(path)
+
+	if link.Scheme != "https" {
 		return false
 	}
 
+	if link.Host != "s3.amazonaws.com" && link.Host != "s3.amazonaws.com:443" {
+		return false
+	}
+
+	if !strings.HasPrefix(link.Path, "/echo.api/") {
+		return false
+	}
 	return true
 }


### PR DESCRIPTION
Hi there,

Alexa can use different certificate URLs, so we need to relax the validation. 

Example of a perfectly valid certificate: https://s3.amazonaws.com/echo.api/echo-api-cert-USAmazon-prod-24005911.pem

Best regards